### PR TITLE
VirusTotal Cmdlet Cleanup

### DIFF
--- a/src/Public/VirusTotal/Get-VTDomainReport.ps1
+++ b/src/Public/VirusTotal/Get-VTDomainReport.ps1
@@ -20,7 +20,7 @@ Function Get-VTDomainReport {
     .OUTPUTS
         PSCustomObject representing the report results.
     .EXAMPLE
-        PS C:\> Get-VtDomainReport -Credential $token -Url "logrhythm.com"
+        PS C:\> Get-VtDomainReport -Url "logrhythm.com"
         ---
         BitDefender category             : computersandsoftware
         https_certificate_date           : 1576852588

--- a/src/Public/VirusTotal/Get-VTHashReport.ps1
+++ b/src/Public/VirusTotal/Get-VTHashReport.ps1
@@ -20,7 +20,7 @@ Function Get-VTHashReport {
     .OUTPUTS
         PSCustomObject representing the report results.
     .EXAMPLE
-        PS C:\> Get-VtHashReport -Credential $token -Hash b57d478a0673352579a8a0199d45e21dc1f7cdcc8fbe355daa9580e5e6b49b80
+        PS C:\> Get-VtHashReport -Hash b57d478a0673352579a8a0199d45e21dc1f7cdcc8fbe355daa9580e5e6b49b80
         ---
         scans         : @{Bkav=; MicroWorld-eScan=; CMC=; CAT-QuickHeal=; McAfee=; Cylance=; Zillya=; SUPERAntiSpyware=; Sangfor=; K7AntiVirus=; K7GW=; Arcabit=; 
                         Baidu=; Cyren=; Symantec=; ESET-NOD32=; TrendMicro-HouseCall=; Avast=; ClamAV=; Kaspersky=; BitDefender=; NANO-Antivirus=; ViRobot=; 

--- a/src/Public/VirusTotal/Get-VTIpReport.ps1
+++ b/src/Public/VirusTotal/Get-VTIpReport.ps1
@@ -19,7 +19,7 @@ Function Get-VTIPReport {
     .OUTPUTS
         PSCustomObject representing the report results.
     .EXAMPLE
-        PS C:\> Get-VtIPReport -Credential $token -IpAddr "13.249.122.117"
+        PS C:\> Get-VtIPReport -IpAddr "13.249.122.117"
         ---
         undetected_urls                  : {http://www.sozcu.com.tr/?gclid=EAIaIQobChMI0aHE_b-Z5gIVxo2yCh0_oQ4kEAAYASAAEgLFHfD_BwE 
                                            68ca8f8906554731273cbfd49e659258f2ce88793601c4159daaa1806a6f467b 0 72 2019-12-10 10:43:44, 

--- a/src/Public/VirusTotal/Get-VTUrlReport.ps1
+++ b/src/Public/VirusTotal/Get-VTUrlReport.ps1
@@ -20,7 +20,7 @@ Function Get-VTUrlReport {
     .OUTPUTS
         PSCustomObject representing the report results.
     .EXAMPLE
-        PS C:\> Get-VtUrlReport -Credential $token -Url "https://logrhythm.com"
+        PS C:\> Get-VtUrlReport -Url "https://logrhythm.com"
         ---
         scan_id       : 9270b9ee778eac9801b130221dda1eb37e68b676a310922cf2b62e63496da404-1570695201
         resource      : https://logrhythm.com


### PR DESCRIPTION
Removed $token from example.  Standard use will have Token established as part of PS Module.