### PR TITLE
Issue in New-TestBuild:

### DIFF
--- a/build/New-TestBuild.ps1
+++ b/build/New-TestBuild.ps1
@@ -85,12 +85,14 @@ Write-Host "===========================================" -ForegroundColor Gray
 
 # New Build
 Write-Host "Creating new build: " -NoNewline
-$NewBuildPath = New-LrtBuild -ReturnPsm1Path
-if (Test-Path $NewBuildPath) {
+try {
+    $NewBuildPath = New-LrtBuild -ReturnPsm1Path
     Write-Host "[Success]" -ForegroundColor Green
-} else {
-    Write-Host "[Failure]" -ForegroundColor Red
-    throw [Exception] "Failed to build LogRhythm.Tools module. Review errors / call stack."
+}
+catch {
+    Write-Host "[Failed]`n" -ForegroundColor Red
+    Write-Host "Exception`n---------`n$($PSItem.Exception.Message)" -ForegroundColor Magenta
+    return
 }
 
 
@@ -99,8 +101,9 @@ Write-Host "Import Build:       " -NoNewline
 try {
     Import-Module $NewBuildPath
 } catch {
-    Write-Host "[Failed]" -ForegroundColor Red
-    throw [Exception] "Failed to import build. Review errors / call stack."
+    Write-Host "[Failed]`n" -ForegroundColor Red
+    Write-Host "Exception`n---------`n$($PSItem.Exception.Message)" -ForegroundColor Magenta
+    return
 }
 Write-Host "[Success]" -ForegroundColor Green
 #endregion


### PR DESCRIPTION
Exceptions weren't being reported properly during the build and import steps. Now, relevant error information is displayed when a step fails.

## Before
![7-22-2020 5-24-03 AM](https://user-images.githubusercontent.com/56445225/88165617-95d10000-cbdb-11ea-9ce1-a4b56df5cbc3.png)

## After
![7-22-2020 5-15-00 AM](https://user-images.githubusercontent.com/56445225/88165555-80f46c80-cbdb-11ea-9227-7ad637194028.png)

## Note
You may want to merge this into your topic branches, but it isn't strictly necessary.