### PR TITLE
Test-LrtPublish (Take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ PowerShell_transcript*
 [Bb]uild/[Rr]elease/*
 [Bb]uild/BuildInfo.json
 
-# Ignore test data
+# Ignore test data and backups
 [Tt]ests/*/data/*
 [Tt]ests/data/*
+
+[Tt]ests/*/backup/*
+[Tt]ests/backup/*

--- a/tests/Lrt.Publisher/Test-LrtPublish.ps1
+++ b/tests/Lrt.Publisher/Test-LrtPublish.ps1
@@ -10,7 +10,7 @@ using namespace System.IO
     be removed so that it can be re-created by the Setup script.
 .PARAMETER RestoreKeys
     If the RestoreKeys switch is set, all xml files that were backed up from LogRhythm.Tools configuration
-    will be replaced once the test has completed.
+    will be restored once the test has completed.
 .INPUTS
     None
 .OUTPUTS
@@ -106,9 +106,9 @@ catch {
     $PSCmdlet.ThrowTerminatingError($PSItem)
 }
 
-# Replace Keys
+# Restore Keys
 if ($RestoreKeys -and $Reset) {
-    Write-Host "Replacing API Keys to $ConfigDirPath"
+    Write-Host "Restoring API Keys to $ConfigDirPath"
     Get-ChildItem -Path $BackupPath -Filter *.xml | Copy-Item -Destination $ConfigDirPath
     
 }

--- a/tests/Lrt.Publisher/Test-LrtPublish.ps1
+++ b/tests/Lrt.Publisher/Test-LrtPublish.ps1
@@ -4,6 +4,13 @@ using namespace System.IO
 <#
 .SYNOPSIS
     End to end testing of the LrtBuilder module, from build to publish.
+.PARAMETER Reset
+    If the Reset switch is provided, then the entire contents of the LogRhythm.Tools configuration directory
+    will be backed up to tests\Lrt.Publisher\backup\ and the configuration directory in %LocalAppData% will
+    be removed so that it can be re-created by the Setup script.
+.PARAMETER RestoreKeys
+    If the RestoreKeys switch is set, all xml files that were backed up from LogRhythm.Tools configuration
+    will be replaced once the test has completed.
 .INPUTS
     None
 .OUTPUTS
@@ -19,11 +26,7 @@ Param(
     [switch] $Reset,
 
     [Parameter(Mandatory = $false, Position = 1)]
-    [switch] $BackupConfig,
-
-    [Parameter(Mandatory = $false , Position = 2)]
-    [ValidateNotNull()]
-    [DirectoryInfo] $Destination
+    [switch] $RestoreKeys
 )
 
 
@@ -42,70 +45,70 @@ $RepoInfo = Get-LrtRepoInfo
 # Config Directory
 $ConfigDirPath = Join-Path -Path ([Environment]::GetFolderPath("LocalApplicationData")) -ChildPath $RepoInfo.ModuleInfo.Name
 
+# Backup location
+$T_BKP = Join-Path -Path $PSScriptRoot -ChildPath "backup"
 
-# Will contain result of Publish-LrtBuild
+# Data = Release.zip extracted files
 $T_DATA = Join-Path -Path $PSScriptRoot -ChildPath "data"
-# Everything inside T_DATA
-$T_CONTENTS = Join-Path -Path $T_DATA -ChildPath "*"
+$T_DATA_FILES = Join-Path -Path $T_DATA -ChildPath "*"
 
-# Tetst Data directories aren't tracked, so create one if ! exist
+
+# Test Data directories aren't tracked, so create if not found.
 if (! (Test-Path $T_DATA)) {
     New-Item -Path $T_DATA -Name "data" -ItemType Directory | Out-Null
+}
+# Test Backup directories aren't tracked, so create if not found.
+if (! (Test-Path $T_BKP)) {
+    New-Item -Path $T_BKP -Name "backup" -ItemType Directory | Out-Null
 }
 #endregion
 
 
 
 #region: Backup                                                                                    
-if ($BackupConfig) {
-    $BackupPath = $Destination.FullName
-    if (! $Destination.Exists) {
-        Write-Warning "Destination directory [$BackupPath] not found. Saving to [Desktop]"
-        $BackupPath = [Environment]::GetFolderPath("Desktop")
-    }
+if ($Reset) {
+    # Backup current config
+    $_ts = ([datetime]::now).ToString('yyyy-MM-dd-mm-ss')
+    $BackupPath = New-Item -Path $T_BKP -ItemType Directory -Name $_ts
+    $BackupItems = Get-ChildItem -Path $ConfigDirPath -Recurse
     try {
-        Copy-Item -Path $ConfigDirPath -Destination $BackupPath
-        Write-Host "Existing configuration saved to $BackupPath"
+        Write-Host "Saving existing configuration to: $($BackupPath.FullName)"
+        $BackupItems | Copy-Item -Destination $BackupPath.FullName
     }
     catch {
         $PSCmdlet.ThrowTerminatingError($PSItem)
     }
-}
-#endregion
 
-
-
-#region: Reset                                                                                     
-if ($Reset) {
+    # Remove config
     try {
         Remove-Item -Path $ConfigDirPath -Recurse -Force -ErrorAction SilentlyContinue
-    }
-    catch {
-        Write-Host "Failed to remove existing Lrt configuration from $ConfigDirPath" -ForegroundColor Yellow
-        $PSCmdlet.ThrowTerminatingError($PSItem)
+    } catch {
+        Write-Host "Faileld to remove existing configuration at $ConfigDirPath"
     }
 }
 #endregion
 
+# Clean out old test data
+Remove-Item -Recurse -Path $T_DATA_FILES -Force -ErrorAction SilentlyContinue
 
-
-#region: Clean                                                                                     
-try {
-    Remove-Item -Recurse -Path $T_CONTENTS -Force -ErrorAction SilentlyContinue
-}
-catch {
-    Write-Host "Failed to remove old test data. Resolve error and try again." -ForegroundColor Yellow
-    $PSCmdlet.ThrowTerminatingError($PSItem)
-}
-#endregion
-
-
-#region: Publish and Run Setup.ps1                                                                 
+# New Build
 $TestRelease = New-LrtBuild -Version 1.0.0 -ReleaseTag (New-LrtReleaseTag) | Publish-LrtBuild -Destination $T_DATA -PassThru
 
-# Extract the results
+# Extract results
 Expand-Archive -Path $TestRelease.FullName -DestinationPath "$T_DATA\lrt-install"
 
-# Run Setup!
-Invoke-Expression -Command "$T_DATA\lrt-install\Setup.ps1"
-#endregion
+# Run Setup
+try {
+    Invoke-Expression -Command "$T_DATA\lrt-install\Setup.ps1" -ErrorAction Stop
+}
+catch {
+    Write-Host "Error occured while executing Setup.ps1"
+    $PSCmdlet.ThrowTerminatingError($PSItem)
+}
+
+# Replace Keys
+if ($RestoreKeys -and $Reset) {
+    Write-Host "Replacing API Keys to $ConfigDirPath"
+    Get-ChildItem -Path $BackupPath -Filter *.xml | Copy-Item -Destination $ConfigDirPath
+    
+}


### PR DESCRIPTION
# Scope
The only change outside of the test script itself is `.gitignore`, which has been updated to ignore the configuration backups. This is the second submission of this feature, after it was accidentally merged with the master branch directly.  That merge has been reverted and this PR is to merge into development.

## Overview

The idea is to make it a little simpler to create a new config for yourself when LrtConfig changes.  Run the test command below, go through the setup prompts to generate/test a new LrtConfig, and it will restore your api keys after so that you don't have to paste your passwords again in setup prompts.

```
> Test-LrtPublish -Reset -ReplaceKeys
```

`-Reset` will:
- Backup all files from the existing configuration in `%localappdata%\LogRhythm.Tools`
- Remove the existing configuration so that a new config file will be generated when Setup is run

`-RestoreKeys` will:
- Take all of the XML files that were backed up by `-Reset` and put them back in `%localappdata%\LogRhythm.Tools`
