### PR TITLE
Feature: Lr Case Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ PowerShell_transcript*
 
 [Tt]ests/*/backup/*
 [Tt]ests/backup/*
+
+_build.ps1

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -37,7 +37,7 @@ if ($ConfigFileInfo.Exists) {
 $LrCaseStatus = [PSCustomObject]@{
     Created     = 1
     Completed   = 2
-    Open        = 3
+    Incident    = 3
     Mitigated   = 4
     Resolved    = 5
 }

--- a/src/Public/LogRhythm/Case/General/Get-LrCaseStatusTable.ps1
+++ b/src/Public/LogRhythm/Case/General/Get-LrCaseStatusTable.ps1
@@ -27,51 +27,88 @@ Function Get-LrCaseStatusTable {
     #>
 
     [CmdletBinding()]
-    Param()
+    Param(
+        [Parameter(
+            Mandatory = $false, 
+            ValueFromPipeline = $true, 
+            Position = 0
+        )]
+        [int] $Number,
 
-    # Create an object for each status
-    $Created = [PSCustomObject]@{
-        Number      = 1
-        Name        = "Created"
-        State       = "Open"
-        Transitions = @("Completed", "Incident")
+
+        [Parameter(
+            Mandatory = $false, 
+            ValueFromPipeline = $true, 
+            Position = 1
+        )]
+        [string] $Name
+    )
+
+    Begin {
+        # Create an object for each status
+        $Created = [PSCustomObject]@{
+            Number      = 1
+            Name        = "Created"
+            State       = "Open"
+            Transitions = @("Completed", "Incident")
+            Type        = "Case"
+        }
+
+        $Completed = [PSCustomObject]@{
+            Number      = 2
+            Name        = "Completed"
+            State       = "Closed"
+            Transitions = @("Created")
+            Type        = "Case"
+        }
+
+        $Incident = [PSCustomObject]@{
+            Number      = 3
+            Name        = "Incident"
+            State       = "Open"
+            Transitions = @("Created", "Mitigated")
+            Type        = "Incident"
+        }
+
+        $Mitigated = [PSCustomObject]@{
+            Number      = 4
+            Name        = "Mitigated"
+            State       = "Open"
+            Transitions = @("Incident", "Resolved")
+            Type        = "Incident"
+        }
+
+        $Resolved = [PSCustomObject]@{
+            Number      = 5
+            Name        = "Resolved"
+            State       = "Closed"
+            Transitions = @("Mitigated")
+            Type        = "Incident"
+        }
+
+
+        # Create List
+        $StatusList = [list[Object]]::new()
+        $StatusList.Add($Created)
+        $StatusList.Add($Completed)
+        $StatusList.Add($Incident)
+        $StatusList.Add($Mitigated)
+        $StatusList.Add($Resolved)
     }
 
-    $Completed = [PSCustomObject]@{
-        Number      = 2
-        Name        = "Completed"
-        State       = "Closed"
-        Transitions = @("Created")
+
+    Process {
+        if ($Number) {
+            return ($StatusList | Where-Object { $_.Number -eq $Number })
+        }
+    
+        if ($Name) {
+            return ($StatusList | Where-Object { $_.Name -eq $Name })
+        }
+
+        return $StatusList
     }
 
-    $Incident = [PSCustomObject]@{
-        Number      = 3
-        Name        = "Incident"
-        State       = "Open"
-        Transitions = @("Created", "Mitigated")
-    }
 
-    $Mitigated = [PSCustomObject]@{
-        Number      = 4
-        Name        = "Mitigated"
-        State       = "Open"
-        Transitions = @("Incident", "Resolved")
-    }
-
-    $Resolved = [PSCustomObject]@{
-        Number      = 5
-        Name        = "Resolved"
-        State       = "Closed"
-        Transitions = @("Mitigated")
-    }
-
-    # Create a list and add each status
-    $StatusList = [list[Object]]::new()
-    $StatusList.Add($Created)
-    $StatusList.Add($Completed)
-    $StatusList.Add($Incident)
-    $StatusList.Add($Mitigated)
-    $StatusList.Add($Resolved)
-
-    return $StatusList
+    End { }
 }

--- a/src/Public/LogRhythm/Case/General/Test-LrCaseIdFormat.ps1
+++ b/src/Public/LogRhythm/Case/General/Test-LrCaseIdFormat.ps1
@@ -59,6 +59,13 @@ Function Test-LrCaseIdFormat {
             Note        =   $null
         }
 
+        
+        # We may have received a full case object.  Check to see if it has a property for ID and Number
+        if ($Id.Id -and $Id.Number) {
+            Write-Verbose "[Test-LrCaseIdFormat]: Detected Id is a Case Object. Using Case.Number for validation."
+            $Id = $Id.Number
+        }
+
         # Check if ID value is an integer
         if ([int]::TryParse($Id, [ref]$_int)) {
             Write-Verbose "[$Me]: Id parses as integer."

--- a/src/Public/LogRhythm/Case/Metrics/Get-LrCaseMetrics.ps1
+++ b/src/Public/LogRhythm/Case/Metrics/Get-LrCaseMetrics.ps1
@@ -183,7 +183,7 @@ Function Get-LrCaseMetrics {
         }
         #endregion
 
-        Start-Sleep -Milliseconds 200
+        Start-Sleep -Milliseconds 50
 
         # End
         return $Response

--- a/src/Public/LogRhythm/Case/Metrics/Get-LrCaseMetrics.ps1
+++ b/src/Public/LogRhythm/Case/Metrics/Get-LrCaseMetrics.ps1
@@ -57,13 +57,17 @@ Function Get-LrCaseMetrics {
 
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $false, Position = 0)]
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            Position = 0
+        )]
+        [object] $Id,
+
+
+        [Parameter(Mandatory = $false, Position = 1)]
         [ValidateNotNull()]
-        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey,
-
-
-        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 1)]
-        [object] $Id
+        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey
     )
 
     Begin {
@@ -81,10 +85,14 @@ Function Get-LrCaseMetrics {
 
         # Enable self-signed certificates and Tls1.2
         Enable-TrustAllCertsPolicy
+
+        $_COUNT = 0
     }
 
 
     Process {
+        $_COUNT++
+
         # Test CaseID Format
         $IdStatus = Test-LrCaseIdFormat $Id
         if ($IdStatus.IsValid -eq $true) {
@@ -92,6 +100,7 @@ Function Get-LrCaseMetrics {
         } else {
             return $IdStatus
         }
+     
         
         # Request URI
         $RequestUrl = $BaseUrl + "/cases/$CaseNumber/metrics"
@@ -114,7 +123,7 @@ Function Get-LrCaseMetrics {
                 $Err = Get-RestErrorMessage $_
                 throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
             }
-        }     
+        }
         #endregion
 
 
@@ -127,7 +136,7 @@ Function Get-LrCaseMetrics {
             # Placeholders
             $d = [datetime]::MinValue
             
-            # Step One: For each category of date, and convert any dates into datetime objects
+            # Step One: For each category of date, convert any dates into datetime objects
             foreach ($category in $Response.PSObject.Properties) {
                 foreach ($property in $category.Value.PSObject.Properties) {
                     if ($property.Value) {
@@ -137,11 +146,15 @@ Function Get-LrCaseMetrics {
                     }
                 }
             }
+
+
             # Step Two: TTD/TTR/TTE/TTC
             $TTD = "N/A"
             $TTR = "N/A"
             $TTE = "N/A"
             $TTC = "N/A"
+
+
             # Add to Response
             $Response | Add-Member -MemberType NoteProperty -Name "TTD" -Value $TTD
             $Response | Add-Member -MemberType NoteProperty -Name "TTR" -Value $TTR
@@ -170,12 +183,14 @@ Function Get-LrCaseMetrics {
         }
         #endregion
 
-
+        Start-Sleep -Milliseconds 200
 
         # End
         return $Response
     }
 
 
-    End { }
+    End {
+        Write-Verbose "Processed $_COUNT cases."
+    }
 }

--- a/src/Public/LogRhythm/Case/Metrics/Measure-LrCaseMetrics.ps1
+++ b/src/Public/LogRhythm/Case/Metrics/Measure-LrCaseMetrics.ps1
@@ -1,0 +1,152 @@
+using namespace System
+using namespace System.IO
+using namespace System.Collections.Generic
+
+Function Measure-LrCaseMetrics {
+    <#
+    .SYNOPSIS
+        Generates an average TTD, TTR, TTE, and TTC for a set of LogRhythm Cases.
+    .DESCRIPTION
+        xxxx
+    .PARAMETER InputObject
+        A collection of LogRhythm Case Objects passed through the pipeline or from 
+        a list or array.
+    .PARAMETER param2
+        xxxx
+    .INPUTS
+        System.Object -> $InputObjectList
+    .OUTPUTS
+        xxxx
+    .EXAMPLE
+        xxxx
+    .EXAMPLE
+        xxxx
+    .LINK
+        https://github.com/LogRhythm-Tools/LogRhythm.Tools
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $true,
+            ValueFromPipeline = $true,
+            Position = 0
+        )]
+        [Object] $InputObject,
+
+
+        [Parameter(Mandatory = $false, Position = 1)]
+        [string[]] $Tags
+    )
+
+
+    Begin {
+        # Total cases, regardless of whether they have a TTD,TTR, etc.
+        $Total_Cases = 0
+        $Total_Incidents = 0
+
+        $TTD_Total = 0
+        $TTD_Count = 0
+
+        $TTR_Total = 0
+        $TTR_Count = 0
+
+        $TTE_Total = 0
+        $TTE_Count = 0
+
+        $TTC_Total = 0
+        $TTC_Count = 0
+
+        $Priority_Total = 0
+
+        $Result = [PSCustomObject]@{
+            Total_Cases      = 0
+            Total_Incidents  = 0
+            Priority_Average = 0
+            TTD_Average      = 0
+            TTR_Average      = 0
+            TTE_Average      = 0
+            TTC_Average      = 0
+        }
+
+        # Add a property for each requested tag to Result object
+        foreach ($tag in $Tags) {
+            $Result | Add-Member -MemberType NoteProperty -Name $tag -Value 0
+        }
+    }
+
+
+    Process {
+
+        # Case Count
+        $Total_Cases++
+
+        # Priority Average
+        $Priority_Total += $InputObject.Priority
+
+        # Incident Count
+        $StatusType = (Get-LrCaseStatusTable -Number $InputObject.Status.Number).Type
+        if ($StatusType -eq "Incident") {
+            $Total_Incidents++
+        }
+
+        # TTD
+        if ( -not ($InputObject.Metrics.TTD -match "N/A")) {
+            $TTD_Total += $InputObject.Metrics.TTD.TotalSeconds
+            $TTD_Count++
+        }
+
+        # TTR
+        if ( -not ($InputObject.Metrics.TTR -match "N/A")) {
+            $TTR_Total += $InputObject.Metrics.TTR.TotalSeconds
+            $TTR_Count++
+        }
+
+        # TTE
+        if ( -not ($InputObject.Metrics.TTE -match "N/A")) {
+            $TTE_Total += $InputObject.Metrics.TTE.TotalSeconds
+            $TTE_Count++
+        }
+        
+        # TTC
+        if ( -not ($InputObject.Metrics.TTC -match "N/A")) {
+            $TTC_Total += $InputObject.Metrics.TTC.TotalSeconds
+            $TTC_Count++
+        }
+
+        # Measure Tags
+        foreach ($tag in $Tags) {
+            if ($InputObject.Tags) {
+                if (($InputObject.Tags | Select-Object -ExpandProperty Text).Contains($tag)) {
+                    $Result.$tag++
+                }
+            }
+        }
+    }
+
+
+    End {
+        $Result.Total_Cases = $Total_Cases
+        $Result.Priority_Average = $Priority_Total / $Total_Cases
+        $Result.Total_Incidents = $Total_Incidents
+
+        if ($TTD_Count -gt 0) {
+            $Result.TTD_Average = [timespan]::FromSeconds($TTD_Total / $TTD_Count)
+        }
+
+        if ($TTR_Count -gt 0) {
+            $Result.TTR_Average = [timespan]::FromSeconds($TTR_Total / $TTR_Count)
+        }
+        
+        if ($TTE_Count -gt 0) {
+            $Result.TTE_Average = [timespan]::FromSeconds($TTE_Total / $TTE_Count)
+        }
+
+        if ($TTC_Count -gt 0) {
+            $Result.TTC_Average = [timespan]::FromSeconds($TTC_Total / $TTC_Count)
+        }
+        
+        
+        return $Result
+     }
+}


### PR DESCRIPTION
# Scope

(Note: Its set to merge to development)

No shared module files have been modified other than `.gitignore`, which will not impact anything. Otherwise all of the commands that have been updated are within `LogRhythm\Case\General` and `LogRhythm\Case\Metrics`

## Purpose

The primary purpose of this PR is to implement Case Metrics for `Get-LrCases` through the `-Metrics` switch.  I kept the addition of the Metrics property optional to reduce overhead on running the command, as oftentimes a user won't require the metrics information.

### Example - `Get-LrCases`

```
> $Resolved = Get-LrCases -Status "Resolved" -CreatedAfter 2020-08-01 -Metrics
> $Resolved[0].Metrics

created          : @{date=8/3/2020 8:11:14 AM; originalDate=8/3/2020 8:11:14 AM; customDate=; note=}
completed        : @{date=; originalDate=; customDate=; note=}
incident         : @{date=8/3/2020 8:32:14 AM; originalDate=8/3/2020 8:32:14 AM; customDate=; note=}
mitigated        : @{date=8/3/2020 8:45:42 AM; originalDate=8/3/2020 8:45:42 AM; customDate=; note=}
resolved         : @{date=8/3/2020 8:47:48 AM; originalDate=8/3/2020 8:47:48 AM; customDate=; note=}
earliestEvidence : @{date=; originalDate=; customDate=; note=}
TTD              : N/A
TTR              : 00:34:27.5469723
TTE              : 00:21:00.3713958
TTC              : 00:36:34.0384613
```

I've also added a command which can be used to conveniently summarize a collection of case metrics:

### Example - `Measure-LrCaseMetrics`
```
> $Resolved | Measure-LrCaseMetrics

Total_Cases      : 25
Total_Incidents  : 25
Priority_Average : 2.76
TTD_Average      : 04:57:39.8470000
TTR_Average      : 01:57:01.0660000
TTE_Average      : 01:14:40.4170000
TTC_Average      : 04:55:09.8050000
```

## Minor Changes

- Support for passing Case objects to `Test-LrCaseIdFormat`.  Just use `ValueFromPipeline` in cmdlets that require a Case Id or Number.  Passing the case will now work, too.

- Fixed an issue with `Get-LrCases` where `-Exact` would return more than 1 result (because LR allows duplicate case names)
    ```
    > $a = Get-LrCases -Name "Specific Alert Name" -Exact -CreatedAfter 2020-08-27 -Verbose
    Warning: More than one case found matching exact name: Specific Alert Name
    Warning: Only the first result will be returned.
    ```

- Fixed an issue in `LogRhythm.Tools.psm1` where one of the LR Case Statuses was incorrect ("Open" should have been "Incident")

- Minor change to `.gitignore` which shouldn't impact anything.




## Files Changed
```
.gitignore
src/Public/LogRhythm/Case/General/Get-LrCaseStatusTable.ps1
src/Public/LogRhythm/Case/General/Get-LrCases.ps1
src/Public/LogRhythm/Case/General/Test-LrCaseIdFormat.ps1
src/Public/LogRhythm/Case/Metrics/Get-LrCaseMetrics.ps1
src/Public/LogRhythm/Case/Metrics/Measure-LrCaseMetrics.ps1
```