### PR TITLE
Hot fix 39

### DIFF
--- a/src/Public/LogRhythm/Case/General/Add-LrCaseCollaborators.ps1
+++ b/src/Public/LogRhythm/Case/General/Add-LrCaseCollaborators.ps1
@@ -40,7 +40,11 @@ Function Add-LrCaseCollaborators {
 
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, Position = 0)]
+        [Parameter(
+            Mandatory = $true, 
+            ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true, 
+            Position = 0)]
         [ValidateNotNull()]
         [object] $Id,
         

--- a/src/Public/LogRhythm/Case/General/Get-LrCasePlaybookProcedures.ps1
+++ b/src/Public/LogRhythm/Case/General/Get-LrCasePlaybookProcedures.ps1
@@ -85,7 +85,7 @@ Function Get-LrCasePlaybookProcedures {
 
     Process {
         # Test CaseID Format
-        $IdStatus = Test-LrCaseIdFormat $Id
+        $IdStatus = Test-LrCaseIdFormat $CaseId
         if ($IdStatus.IsValid -eq $true) {
             $CaseNumber = $IdStatus.CaseNumber
         } else {

--- a/src/Public/LogRhythm/Case/General/New-LRCase.ps1
+++ b/src/Public/LogRhythm/Case/General/New-LRCase.ps1
@@ -125,7 +125,7 @@ Function New-LrCase {
             name = $Name
             priority = $Priority
             externalId = $null
-            dueDate = [Xml.XmlConvert]::ToString(($DueDate),[Xml.XmlDateTimeSerializationMode]::Utc)
+            dueDate = ($DueDate.ToUniversalTime()).ToString("yyyy-MM-ddTHH:mm:ssZ")
             summary = $Summary
         }
         $Body = $Body | ConvertTo-Json

--- a/src/Public/LogRhythm/Case/General/Update-LRCase.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LRCase.ps1
@@ -1,33 +1,69 @@
 using namespace System
-using namespace System.IO
-using namespace System.Collections.Generic
 
 Function Update-LrCase {
     <#
     .SYNOPSIS
-        Update an existing case.
+        Update case information. For example, the case name, priority, and due date.
     .DESCRIPTION
-        The Update-LrCase cmdlet updates an existing case and returns the updated case record as a PSCustomObject.
+        The Update-LrCase cmdlet updates an existing case.
+    .PARAMETER Id
+        Unique identifier for the case, either as an RFC 4122 formatted string, or as
+        a number.
+    .PARAMETER ExternalId
+        Externally defined identifier for the case.
+    .PARAMETER Name
+        Name of the case.
+    .PARAMETER Priority
+        Priority of the case. Valid values: 1-5
+    .PARAMETER DueDate
+        When the case is due, either as an Rfc3339 formatted string, or as a [DateTime]
+    .PARAMETER Summary
+        Note summarizing the case.
+    .PARAMETER Resolution
+        Description of how the case was resolved.
     .PARAMETER Credential
         PSCredential containing an API Token in the Password field.
         Note: You can bypass the need to provide a Credential by setting
         the preference variable $LrtConfig.LogRhythm.ApiKey
         with a valid Api Token.
-    .PARAMETER Name
-        Name of the case.
-    .PARAMETER Priority
-        (int 1-5) Priority of the case.
-    .PARAMETER DueDate
-        When the case is due, as [System.DateTime] or a date-parsable [System.String]
-        If ommitted, a due date will be set for 24 hours from the current time.
-    .PARAMETER Summary
-        Note summarizing the case.
     .INPUTS
-        Name, Priority, DueDate, and Summary can all be sent by name through the pipeline.
+        [System.Object]   ->  Id
     .OUTPUTS
-        PSCustomObject representing the newly created case.
+        If the PassThru switch is provided, a PSCustomObject representing the modified
+        LogRhythm Case will be returned.
     .EXAMPLE
-        PS C:\> Update-LrCase -Id 5 -Name "test" -Priority 5 -Summary "test summary" -DueDate "10-20-2020 14:22:11"
+        PS C:\> Update-LrCase -Id 4481 -Summary "My New Summary"
+        ---
+        In this example we updated the Summary of Case number 4481 to "My New Summary".
+        As we did not include the PassThru parameter, there will be no output.
+    .EXAMPLE
+        In this example we will use the pipeline to pass a case object to Update-LrCase
+        and update every field we can.
+        
+        
+        PS C:\> $case = Get-LrCaseById -Id 4481
+
+        PS C:\> $case | Update-LrCase -ExternalId "Ext1212" -Name "Example Case" -Priority 3 -DueDate 2020-11-01 -Summary "Here's my summary" -Resolution "a resolution!" -PassThru
+
+        ---
+        id                      : ACAA4DF4-E810-4AF5-A3FA-2B3BA47BD237
+        number                  : 4481
+        externalId              : Ext1212
+        dateCreated             : 2020-09-16T12:11:38.1893786Z
+        dateUpdated             : 2020-09-17T09:58:21.8816109Z
+        dateClosed              :
+        owner                   : @{number=11; name=API, Example; disabled=False}
+        lastUpdatedBy           : @{number=11; name=API, Example; disabled=False}
+        name                    : Example Case
+        status                  : @{name=Created; number=1}
+        dueDate                 : 2020-11-01T05:00:00Z
+        resolution              : a resolution!
+        resolutionDateUpdated   : 2020-09-17T09:58:21.8816109Z
+        resolutionLastUpdatedBy : @{number=11; name=API, Example; disabled=False}
+        summary                 : Here's my summary
+        entity                  : @{number=-100; name=Global Entity; fullName=Global Entity}
+        collaborators           : {@{number=11; name=API, Example; disabled=False}, @{number=19; name=Smith, Bob; disabled=False}}
+        tags                    : {}
     .NOTES
         LogRhythm-API
     .LINK
@@ -36,35 +72,61 @@ Function Update-LrCase {
 
     [CmdletBinding()]
     Param(
-        [Parameter(Mandatory=$false, Position=0)]
+        [Parameter(
+            Mandatory = $true, 
+            ValueFromPipeline = $true, 
+            ValueFromPipelineByPropertyName = $true, 
+            Position = 0
+        )]
         [ValidateNotNull()]
-        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey,
-
-        [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName = $true, Position=1)]
         [object] $Id,
 
-        [Parameter(Mandatory=$false, ValueFromPipelineByPropertyName = $true, Position=2)]
+        
+        [Parameter(Mandatory = $false, Position = 1)]
+        [ValidateLength(0,250)]
+        [string] $ExternalId,
+        
+
+        [Parameter(Mandatory = $false, Position = 2)]
         [ValidateLength(1,250)]
         [string] $Name,
 
-        [Parameter(Mandatory=$false, ValueFromPipelineByPropertyName = $true, Position=3)]
+
+        [Parameter(Mandatory = $false, Position = 3)]
         [ValidateRange(1,5)]
         [int] $Priority,
 
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 4)]
+
+        [Parameter(Mandatory = $false, Position = 4)]
         [DateTime] $DueDate,
 
-        [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 5)]
-        [ValidateLength(1,10000)]
-        [string] $Summary
+
+        [Parameter(Mandatory = $false, Position = 5)]
+        [ValidateLength(0,10000)]
+        [string] $Summary,
+
+
+        [Parameter(Mandatory = $false, Position = 6)]
+        [ValidateLength(0,500)]
+        [string] $Resolution,
+
+
+        [Parameter(Mandatory = $false, Position = 8)]
+        [switch] $PassThru,
+
+
+        [Parameter(Mandatory = $false, Position = 9)]
+        [ValidateNotNull()]
+        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey
     )
+
 
     Begin {
         $Me = $MyInvocation.MyCommand.Name
-
+        
         $BaseUrl = $LrtConfig.LogRhythm.CaseBaseUrl
         $Token = $Credential.GetNetworkCredential().Password
-        
+
         # Enable self-signed certificates and Tls1.2
         Enable-TrustAllCertsPolicy
 
@@ -75,80 +137,96 @@ Function Update-LrCase {
 
         # Request Method
         $Method = $HttpMethod.Put
+
+        # Set initial ProcessedCount
+        $ProcessedCount = 0
     }
 
+
     Process {
-        # Test CaseID Format
+        # Test CaseId Format
         $IdStatus = Test-LrCaseIdFormat $Id
         if ($IdStatus.IsValid -eq $true) {
             $CaseNumber = $IdStatus.CaseNumber
         } else {
             return $IdStatus
-        } 
-
-        $CaseDetails = Get-LrCaseById -Id $CaseNumber
-
-        if ($Name) {
-            $_name = $Name
-        } else {
-            $_name = $CaseDetails.Name
         }
 
-        if ($DueDate) {
-            $_dueDate = $DueDate
-        } else {
-            $_dueDate = $CaseDetails.dueDate
-        }
-
-        if ($Priority) {
-            $_priority = $Priority
-        } else {
-            $_priority = $CaseDetails.priority
-        }
-
-        if ($Summary) {
-            $_summary = $Summary
-        } else {
-            $_summary = $CaseDetails.summary
-        }
-
+        # Request URI
         $RequestUrl = $BaseUrl + "/cases/$CaseNumber/"
 
-        # Request Body
-        $Body = [PSCustomObject]@{
-            name = $_name
-            priority = $_priority
-            externalId = $null
-            dueDate = [Xml.XmlConvert]::ToString(($_dueDate),[Xml.XmlDateTimeSerializationMode]::Utc)
-            summary = $_summary
-        }
-        $Body = $Body | ConvertTo-Json
 
-        # Send Request
-        if ($PSEdition -eq 'Core'){
+        #region: Create Json Body                                                                  
+        $Body = [PSCustomObject]@{}
+        
+        # Parameter: ExternalId
+        if (! [string]::IsNullOrEmpty($ExternalId)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "externalId" -Value $ExternalId
+        }
+
+        # Parameter: Name
+        if (! [string]::IsNullOrEmpty($Name)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "name" -Value $Name
+        }
+
+        # Parameter: Priority
+        if ($Priority -gt 0) {
+            $Body | Add-Member -MemberType NoteProperty -Name "priority" -Value $Priority
+        }
+
+        # Parameter: DueDate
+        if ($DueDate) {
+            $_dueDate = ($DueDate.ToUniversalTime()).ToString("yyyy-MM-ddTHH:mm:ssZ")
+            $Body | Add-Member -MemberType NoteProperty -Name "dueDate" -Value $_dueDate
+        }
+
+        # Parameter: Summary
+        if (! [string]::IsNullOrEmpty($Summary)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "summary" -Value $Summary
+        }
+
+        # Parameter: Resolution
+        if (! [string]::IsNullOrEmpty($Resolution)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "resolution" -Value $Resolution
+        }
+
+        # Important - Convert to JSON 
+        $Body = $Body | ConvertTo-Json
+        #endregion
+        
+
+        #region: Send Request                                                                      
+        Write-Verbose "[$Me]: request body is:`n$Body"
+
+        if ($PSEdition -eq 'Core') {
             try {
                 $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body -SkipCertificateCheck
-                Write-Verbose "[$Me]: Created Case $($Response.id)" 
-            }
-            catch {
+            } catch {
                 $Err = Get-RestErrorMessage $_
                 throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
             }
         } else {
             try {
                 $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body
-                Write-Verbose "[$Me]: Created Case $($Response.id)"
             }
             catch [System.Net.WebException] {
                 $Err = Get-RestErrorMessage $_
                 throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
             }
         }
+        #endregion
+        
 
-        # Done!
-        return $Response
+        $ProcessedCount++
+
+        # Return
+        if ($PassThru) {
+            return $Response
+        }
     }
 
-
-    End { }
+    
+    End { 
+        Write-Verbose "Updated $ProcessedCount cases."
+    }
 }

--- a/src/Public/LogRhythm/Case/General/Update-LrCase.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCase.ps1
@@ -1,0 +1,232 @@
+using namespace System
+
+Function Update-LrCase {
+    <#
+    .SYNOPSIS
+        Update case information. For example, the case name, priority, and due date.
+    .DESCRIPTION
+        The Update-LrCase cmdlet updates an existing case.
+    .PARAMETER Id
+        Unique identifier for the case, either as an RFC 4122 formatted string, or as
+        a number.
+    .PARAMETER ExternalId
+        Externally defined identifier for the case.
+    .PARAMETER Name
+        Name of the case.
+    .PARAMETER Priority
+        Priority of the case. Valid values: 1-5
+    .PARAMETER DueDate
+        When the case is due, either as an Rfc3339 formatted string, or as a [DateTime]
+    .PARAMETER Summary
+        Note summarizing the case.
+    .PARAMETER Resolution
+        Description of how the case was resolved.
+    .PARAMETER Credential
+        PSCredential containing an API Token in the Password field.
+        Note: You can bypass the need to provide a Credential by setting
+        the preference variable $LrtConfig.LogRhythm.ApiKey
+        with a valid Api Token.
+    .INPUTS
+        [System.Object]   ->  Id
+    .OUTPUTS
+        If the PassThru switch is provided, a PSCustomObject representing the modified
+        LogRhythm Case will be returned.
+    .EXAMPLE
+        PS C:\> Update-LrCase -Id 4481 -Summary "My New Summary"
+        ---
+        In this example we updated the Summary of Case number 4481 to "My New Summary".
+        As we did not include the PassThru parameter, there will be no output.
+    .EXAMPLE
+        In this example we will use the pipeline to pass a case object to Update-LrCase
+        and update every field we can.
+        
+        
+        PS C:\> $case = Get-LrCaseById -Id 4481
+
+        PS C:\> $case | Update-LrCase -ExternalId "Ext1212" -Name "Example Case" -Priority 3 -DueDate 2020-11-01 -Summary "Here's my summary" -Resolution "a resolution!" -PassThru
+
+        ---
+        id                      : ACAA4DF4-E810-4AF5-A3FA-2B3BA47BD237
+        number                  : 4481
+        externalId              : Ext1212
+        dateCreated             : 2020-09-16T12:11:38.1893786Z
+        dateUpdated             : 2020-09-17T09:58:21.8816109Z
+        dateClosed              :
+        owner                   : @{number=11; name=API, Example; disabled=False}
+        lastUpdatedBy           : @{number=11; name=API, Example; disabled=False}
+        name                    : Example Case
+        status                  : @{name=Created; number=1}
+        dueDate                 : 2020-11-01T05:00:00Z
+        resolution              : a resolution!
+        resolutionDateUpdated   : 2020-09-17T09:58:21.8816109Z
+        resolutionLastUpdatedBy : @{number=11; name=API, Example; disabled=False}
+        summary                 : Here's my summary
+        entity                  : @{number=-100; name=Global Entity; fullName=Global Entity}
+        collaborators           : {@{number=11; name=API, Example; disabled=False}, @{number=19; name=Smith, Bob; disabled=False}}
+        tags                    : {}
+    .NOTES
+        LogRhythm-API
+    .LINK
+        https://github.com/LogRhythm-Tools/LogRhythm.Tools
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $true, 
+            ValueFromPipeline = $true, 
+            ValueFromPipelineByPropertyName = $true, 
+            Position = 0
+        )]
+        [ValidateNotNull()]
+        [object] $Id,
+
+        
+        [Parameter(Mandatory = $false, Position = 1)]
+        [ValidateLength(0,250)]
+        [string] $ExternalId,
+        
+
+        [Parameter(Mandatory = $false, Position = 2)]
+        [ValidateLength(1,250)]
+        [string] $Name,
+
+
+        [Parameter(Mandatory = $false, Position = 3)]
+        [ValidateRange(1,5)]
+        [int] $Priority,
+
+
+        [Parameter(Mandatory = $false, Position = 4)]
+        [DateTime] $DueDate,
+
+
+        [Parameter(Mandatory = $false, Position = 5)]
+        [ValidateLength(0,10000)]
+        [string] $Summary,
+
+
+        [Parameter(Mandatory = $false, Position = 6)]
+        [ValidateLength(0,500)]
+        [string] $Resolution,
+
+
+        [Parameter(Mandatory = $false, Position = 8)]
+        [switch] $PassThru,
+
+
+        [Parameter(Mandatory = $false, Position = 9)]
+        [ValidateNotNull()]
+        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey
+    )
+
+
+    Begin {
+        $Me = $MyInvocation.MyCommand.Name
+        
+        $BaseUrl = $LrtConfig.LogRhythm.CaseBaseUrl
+        $Token = $Credential.GetNetworkCredential().Password
+
+        # Enable self-signed certificates and Tls1.2
+        Enable-TrustAllCertsPolicy
+
+        # Request Headers
+        $Headers = [Dictionary[string,string]]::new()
+        $Headers.Add("Authorization", "Bearer $Token")
+        $Headers.Add("Content-Type","application/json")
+
+        # Request Method
+        $Method = $HttpMethod.Put
+
+        # Set initial ProcessedCount
+        $ProcessedCount = 0
+    }
+
+
+    Process {
+        # Test CaseId Format
+        $IdStatus = Test-LrCaseIdFormat $Id
+        if ($IdStatus.IsValid -eq $true) {
+            $CaseNumber = $IdStatus.CaseNumber
+        } else {
+            return $IdStatus
+        }
+
+        # Request URI
+        $RequestUrl = $BaseUrl + "/cases/$CaseNumber/"
+
+
+        #region: Create Json Body                                                                  
+        $Body = [PSCustomObject]@{}
+        
+        # Parameter: ExternalId
+        if (! [string]::IsNullOrEmpty($ExternalId)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "externalId" -Value $ExternalId
+        }
+
+        # Parameter: Name
+        if (! [string]::IsNullOrEmpty($Name)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "name" -Value $Name
+        }
+
+        # Parameter: Priority
+        if ($Priority -gt 0) {
+            $Body | Add-Member -MemberType NoteProperty -Name "priority" -Value $Priority
+        }
+
+        # Parameter: DueDate
+        if ($DueDate) {
+            $_dueDate = ($DueDate.ToUniversalTime()).ToString("yyyy-MM-ddTHH:mm:ssZ")
+            $Body | Add-Member -MemberType NoteProperty -Name "dueDate" -Value $_dueDate
+        }
+
+        # Parameter: Summary
+        if (! [string]::IsNullOrEmpty($Summary)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "summary" -Value $Summary
+        }
+
+        # Parameter: Resolution
+        if (! [string]::IsNullOrEmpty($Resolution)) {
+            $Body | Add-Member -MemberType NoteProperty -Name "resolution" -Value $Resolution
+        }
+
+        # Important - Convert to JSON 
+        $Body = $Body | ConvertTo-Json
+        #endregion
+        
+
+        #region: Send Request                                                                      
+        Write-Verbose "[$Me]: request body is:`n$Body"
+
+        if ($PSEdition -eq 'Core') {
+            try {
+                $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body -SkipCertificateCheck
+            } catch {
+                $Err = Get-RestErrorMessage $_
+                throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
+            }
+        } else {
+            try {
+                $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body
+            }
+            catch [System.Net.WebException] {
+                $Err = Get-RestErrorMessage $_
+                throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
+            }
+        }
+        #endregion
+        
+
+        $ProcessedCount++
+
+        # Return
+        if ($PassThru) {
+            return $Response
+        }
+    }
+
+    
+    End { 
+        Write-Verbose "Updated $ProcessedCount cases."
+    }
+}

--- a/src/Public/LogRhythm/Case/General/Update-LrCaseOwner.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCaseOwner.ps1
@@ -1,0 +1,156 @@
+using namespace System
+using namespace System.IO
+using namespace System.Collections.Generic
+
+Function Update-LrCaseOwner {
+    <#
+    .SYNOPSIS
+        Update the owner of a case. The new owner must already be a collaborator on the case.
+    .DESCRIPTION
+        xxxx
+    .PARAMETER Id
+        Unique identifier for the case, either as an RFC 4122 formatted string, or as
+        a number.
+    .INPUTS
+        xxxx
+    .OUTPUTS
+        xxxx
+    .EXAMPLE
+        xxxx
+    .EXAMPLE
+        xxxx
+    .LINK
+        https://github.com/LogRhythm-Tools/LogRhythm.Tools
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(
+            Mandatory = $true, 
+            ValueFromPipeline = $true, 
+            ValueFromPipelineByPropertyName = $true, 
+            Position = 0
+        )]
+        [ValidateNotNull()]
+        [object] $Id,
+
+
+        [Parameter(Mandatory = $true, Position = 1)]
+        [ValidateNotNullOrEmpty()]
+        [string] $Name,
+
+
+        [Parameter(Mandatory = $false, Position = 2)]
+        [switch] $PassThru,
+
+
+        [Parameter(Mandatory = $false, Position = 3)]
+        [ValidateNotNull()]
+        [pscredential] $Credential = $LrtConfig.LogRhythm.ApiKey
+    )
+
+
+    Begin {
+        $Me = $MyInvocation.MyCommand.Name
+    
+        $BaseUrl = $LrtConfig.LogRhythm.CaseBaseUrl
+        $Token = $Credential.GetNetworkCredential().Password
+        
+        # Enable self-signed certificates and Tls1.2
+        Enable-TrustAllCertsPolicy
+
+        # Request Headers
+        $Headers = [Dictionary[string,string]]::new()
+        $Headers.Add("Authorization", "Bearer $Token")
+        $Headers.Add("Content-Type","application/json")
+
+        # Request URI   
+        $Method = $HttpMethod.Put
+    }
+
+
+    Process {
+
+        #region: Validate Parameters                                                               
+        # Test CaseId Format
+        $IdStatus = Test-LrCaseIdFormat $Id
+        if ($IdStatus.IsValid -eq $true) {
+            $CaseNumber = $IdStatus.CaseNumber
+        } else {
+            return $IdStatus
+        }
+
+
+        # Validate Name + Is Collaborator
+        $UserNumber = 0
+        $NameInfo = Test-LrUserIdFormat -Id $Name
+        if ($NameInfo.IsValid) {
+            # User by Name
+            if ($NameInfo.IsName) {
+                $User = Get-LrUserNumber -User $NameInfo.Value
+                if ($User) {
+                    $UserNumber = $User
+                } else {
+                    throw [ArgumentException] "Unable to find a user with name $Name."
+                }
+            }
+            # User by Number
+            if ($NameInfo.IsInt) {
+                $UserNumber = $NameInfo.Value
+            }
+
+            # Make sure user is a collaborator on case
+            $CaseCollaborators = Get-LrCaseById -Id $CaseNumber | Select-Object -ExpandProperty collaborators
+            if ($CaseCollaborators) {
+                if (!$CaseCollaborators.number -contains $UserNumber) {
+                    throw [ArgumentException] "Parameter [Name:$Name] is not a collaborator on case $CaseNumber"
+                }
+            }
+        } else {
+            throw [ArgumentException] "Unable to find an active LogRhythm ID for $Name."
+        }
+
+        if (! $UserNumber) {
+            throw [ArgumentException] "Unable to find an active LogRhythm ID for $Name."
+        }
+        #endregion
+
+
+
+        #region: Send Request                                                                      
+        # Request URI
+        $RequestUrl = $BaseUrl + "/cases/$CaseNumber/actions/changeOwner/"
+
+        # Request Body
+        $Body = [PSCustomObject]@{ number = $UserNumber } | ConvertTo-Json
+        
+        Write-Verbose "[$Me]: request body is:`n$Body"
+
+        if ($PSEdition -eq 'Core') {
+            try {
+                $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body -SkipCertificateCheck
+            } catch {
+                $Err = Get-RestErrorMessage $_
+                throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
+            }
+        } else {
+            try {
+                $Response = Invoke-RestMethod $RequestUrl -Headers $Headers -Method $Method -Body $Body
+            }
+            catch [System.Net.WebException] {
+                $Err = Get-RestErrorMessage $_
+                throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
+            }
+        }
+        #endregion
+
+
+        # Return
+        if ($PassThru) {
+            return $Response
+        }
+    }
+
+
+    End { }
+}

--- a/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
@@ -126,7 +126,7 @@ Function Update-LrCasePlaybookProcedure {
 
 
         [Parameter( Mandatory = $false, Position = 6)]
-        [ValidateNotNullOrEmpty()]
+        [ValidateSet('NotCompleted', 'Completed', 'Skipped')]
         [string] $Status,
 
 
@@ -155,7 +155,7 @@ Function Update-LrCasePlaybookProcedure {
 
     Process {
         # Test CaseID Format
-        $IdStatus = Test-LrCaseIdFormat $Id
+        $IdStatus = Test-LrCaseIdFormat $CaseId
         if ($IdStatus.IsValid -eq $true) {
             $CaseNumber = $IdStatus.CaseNumber
         } else {
@@ -263,21 +263,6 @@ Function Update-LrCasePlaybookProcedure {
             }
         }
 
-        # Validate Status is proper
-        if ($Status) {
-            $ValidStatus = @("notcompleted", "completed", "skipped")
-            
-            if ($ValidStatus.Contains($Status.ToLower())) {
-                Switch ($Status.ToLower())
-                {
-                 notcompleted { $Status = "NotCompleted" }
-                 completed { $Status = "Completed" }
-                 skipped { $Status = "Skipped" }
-                }
-            } else {
-                throw [ArgumentException] "Parameter [Status] should be: NotCompleted, Completed, or Skipped."
-            }
-        }
 
         # Validate Assignee is valid
         if ($Assignee) {

--- a/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
@@ -99,6 +99,7 @@ Function Update-LrCasePlaybookProcedure {
         [Parameter(
             Mandatory = $true, 
             ValueFromPipeline = $true,
+            ValueFromPipelineByPropertyName = $true,
             Position = 2
         )]
         [ValidateNotNull()]

--- a/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
@@ -86,12 +86,7 @@ Function Update-LrCasePlaybookProcedure {
     #>
     [CmdletBinding()]
     Param(
-        [Parameter(
-            Mandatory = $true, 
-            ValueFromPipeline = $true, 
-            ValueFromPipelineByPropertyName = $true, 
-            Position = 0
-        )]
+        [Parameter(Mandatory = $true, Position = 0)]
         [ValidateNotNull()]
         [object] $CaseId,
 
@@ -103,7 +98,7 @@ Function Update-LrCasePlaybookProcedure {
 
         [Parameter(
             Mandatory = $true, 
-            ValueFromPipelineByPropertyName = $true, 
+            ValueFromPipeline = $true,
             Position = 2
         )]
         [ValidateNotNull()]

--- a/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
+++ b/src/Public/LogRhythm/Case/General/Update-LrCasePlaybookProcedure.ps1
@@ -268,7 +268,7 @@ Function Update-LrCasePlaybookProcedure {
         if ($Assignee) {
             $AssigneeType = Test-LrUserIdFormat -Id $Assignee
             if ($AssigneeType.IsInt -eq $false) {
-                $AssigneeResult = Get-LrUsers -Name $Assignee
+                $AssigneeResult = Get-LrUsers -Name $Assignee -Exact
                 Write-Verbose "[$Me]: Assignee String: $Assignee Assignee Result: $($AssigneeResult.Name)"
                 if ($AssigneeResult) {
                     if ($AssigneeResult.disabled -eq $true) {

--- a/src/Public/LogRhythm/Case/Procedures/Test-LrProcedureIdFormat.ps1
+++ b/src/Public/LogRhythm/Case/Procedures/Test-LrProcedureIdFormat.ps1
@@ -47,7 +47,15 @@ Function Test-LrProcedureIdFormat {
         $_int = 1  
     }
 
+
     Process {
+        # We may have received a full procedure object.  
+        # Check to see if it has a property for ID. If it does, use that.
+        if ($Id.Id) {
+            Write-Verbose "[Test-LrProcedureIdFormat]: Detected Id is a Procedure object. Using Procedure.Id for validation."
+            $Id = $Id.Id
+        }
+
         # Check if ID value is an integer
         if ([int]::TryParse($Id, [ref]$_int)) {
             Write-Verbose "[$Me]: Id parses as integer."
@@ -60,13 +68,15 @@ Function Test-LrProcedureIdFormat {
             $OutObject.IsValid = $true
             $OutObject.IsGuid = $true
         } elseif (($Id -Is [String])) {
-            $OutObject.Value = $Id.ToString()
+            # If it isn't either Guid or Int, and we have a string, then it must be a name.
+            $OutObject.IsName = $true
+            $OutObject.Value = $Id
             $OutObject.IsValid = $true
         }
 
         return $OutObject
     }
 
-    End {
-    }
+    
+    End { }
 }

--- a/src/Public/LogRhythm/Case/Procedures/Test-LrProcedureIdFormat.ps1
+++ b/src/Public/LogRhythm/Case/Procedures/Test-LrProcedureIdFormat.ps1
@@ -19,9 +19,12 @@ Function Test-LrProcedureIdFormat {
         System.Object with IsGuid, IsValid, Value
     .EXAMPLE
         C:\PS> Test-LrProcedureIdFormat "5831f290-4798-4148-8165-01317d49afea"
-        IsGuid IsValid Value
-        ------ ------- -----
-         False    True 181
+        ---
+        IsGuid  : True
+        IsInt   : False
+        IsName  : False
+        IsValid : True
+        Value   : 5831f290-4798-4148-8165-01317d49afea
     .LINK
         https://github.com/LogRhythm-Tools/LogRhythm.Tools
     #>
@@ -39,12 +42,13 @@ Function Test-LrProcedureIdFormat {
         $OutObject = [PSCustomObject]@{
             IsGuid      =   $false
             IsInt       =   $false
+            IsName      =   $false
             IsValid     =   $false
             Value       =   $Id
         }
 
-        # https://docs.microsoft.com/en-us/dotnet/api/system.int32.tryparse
-        $_int = 1  
+        # [ref] for Int.TryParse()
+        $_int = 0
     }
 
 

--- a/src/Public/LogRhythm/Case/Users/Test-LrUserIdFormat.ps1
+++ b/src/Public/LogRhythm/Case/Users/Test-LrUserIdFormat.ps1
@@ -36,31 +36,24 @@ Function Test-LrUserIdFormat {
     Begin {
         # [Ref] placeholder for TryParse
         $_int = 0
-
-        # Output object
-        $OutObject = [PSCustomObject]@{
-            IsInt       =   $false
-            IsValid     =   $false
-            Value       =   $Id
-        }
     }
 
     Process {
         $OutObject = [PSCustomObject]@{
             IsInt       =   $false
+            IsName      =   $false
             IsValid     =   $false
             Value       =   $Id
         }
-
+        
         # Check if ID value is an integer
         if ([int]::TryParse($Id, [ref]$_int)) {
             Write-Verbose "[$Me]: Id parses as integer."
-            $OutObject.Value = $Id.ToString()
             $OutObject.IsValid = $true
             $OutObject.IsInt = $true
         # Check if ID value is a String
         } elseif (($Id -Is [String])) {
-            $OutObject.Value = $Id.ToString()
+            $OutObject.IsName = $true
             $OutObject.IsValid = $true
         }
 

--- a/src/Public/LogRhythm/Case/Users/Test-LrUserIdFormat.ps1
+++ b/src/Public/LogRhythm/Case/Users/Test-LrUserIdFormat.ps1
@@ -33,15 +33,18 @@ Function Test-LrUserIdFormat {
         [object] $Id
     )
 
-    $OutObject = [PSCustomObject]@{
-        IsInt       =   $false
-        IsValid     =   $false
-        Value       =   $Id
-    }
+
 
     Begin {
-        # https://docs.microsoft.com/en-us/dotnet/api/system.int32.tryparse
+        # [Ref] placeholder for TryParse
         $_int = 0
+
+        # Output object
+        $OutObject = [PSCustomObject]@{
+            IsInt       =   $false
+            IsValid     =   $false
+            Value       =   $Id
+        }
     }
 
     Process {


### PR DESCRIPTION
## Overview

Mostly bugfixes, but two larger changes:

- Overhaul of `Update-LrCase` as we discussed
- New command: `Update-LrCaseOwner`

Please review if you have time, otherwise I will merge this tomorrow evening.  Ping me on slack if you have questions or comments.


------------------------------------------------
Create Update-LrCaseOwner.ps1
------------------------------------------------
New command: Update-LrCaseOwner - changes the owner of a case.  must be a collaborator.



------------------------------------------------
Update Test-LrUserIdFormat.ps1
------------------------------------------------
1. OutObject was defined twice, removed the one from the Begin block
2. Added option to check for "IsName" as that's the only other possibility.



------------------------------------------------
Update Update-LrCasePlaybookProcedure.ps1
------------------------------------------------
Some logic was incorrect in command, overhauled some portions of this and tested.



------------------------------------------------
Update Add-LrCaseCollaborators.ps1
------------------------------------------------
Added ValueFromPipeline to Id parameter so that Case objects can be piped to Add-LrCaseCollaborators



------------------------------------------------
Update Get-LrCaseMetrics.ps1
------------------------------------------------
Added additional checks to prevent rate limit exceptions - when rate limit is hit, command will throttle and re-send any failed requests.


------------------------------------------------
Update Test-LrProcedureIdFormat.ps1
------------------------------------------------
Add support for testing procedure objects
Added IsName feature
Updated example output



------------------------------------------------
Update Update-LRCase.ps1
------------------------------------------------
This version:
1. fixes the DueDate offset issue
2. has expanded example with object result
3. only updates fields requested to be changed - if you only specify DueDate param, only DueDate is updated (the rest of the fields are omitted from the json body)
4. Implements PassThru
5. Includes the "Resolution" field



------------------------------------------------
Update Update-LrCasePlaybookProcedure.ps1
------------------------------------------------
Update pipeline support for Procedure IDs as opposed to Case ID - more likely to iterate over all the steps of a playbook.



------------------------------------------------
Update New-LRCase.ps1
------------------------------------------------
Small fix to address a DueDate UTC conversion issue when creating a new case.



------------------------------------------------
Update Update-LrCasePlaybookProcedure.ps1
------------------------------------------------
3. If the username provided to the command results in more than one account, we need to handle this.  Fix: add `-Exact` parameter to `Get-LrUsers`.



------------------------------------------------
Update Update-LrCasePlaybookProcedure.ps1
------------------------------------------------
1.  This command uses `CaseId`, and `Id` for the id of the playbook attached to a case.  Currently the command is sending `Id` to validate `CaseId` which will always result in an error.  Fix: Pass `CaseId` instead of `Id` for `Test-LrCaseIdFormat` (line 158)
2. Add validation to `Status` parameter.  As a result lines 267-280 are no longer needed.



------------------------------------------------
Update Get-LrCasePlaybookProcedures.ps1
------------------------------------------------
Fix parameter for Test-LrCaseIdFormat
