### PR TITLE
New features: Proxy aware

### DIFF
--- a/dist/Setup.ps1
+++ b/dist/Setup.ps1
@@ -249,6 +249,31 @@ foreach($ConfigCategory in $LrtConfigInput.PSObject.Properties) {
     }
     #endregion
 
+    #region: Credential Creation                                                                       
+    if ($ConfigCategory.Value.HasCredential) {
+
+        # Prompt for Username - no validation other than (length > 2 and < 101)
+        $Username = Confirm-StringPattern -Message "  > Please enter your Username" `
+            -Pattern "^.*$" `
+            -Hint 'Username is any letters, numbers and any of the following: "-",".","\", "@", "_"' `
+            -AllowChars @("-",".","\", "@", "_")
+
+        # Make sure Username is not empty, as it otherwise cause error
+        if ([string]::IsNullOrEmpty($Username.Value))
+        {
+            $Username.Value = $ConfigCategory.Name
+        }
+
+        # Create credential + username
+        $Result = Get-InputCredential `
+            -AppId $ConfigCategory.Name `
+            -AppName $ConfigCategory.Value.Name `
+            -Username $Username.Value `
+            -UserCredential
+
+    }
+    #endregion
+
 
 
     # Write Config

--- a/dist/common/LogRhythm.Tools.json
+++ b/dist/common/LogRhythm.Tools.json
@@ -3,6 +3,14 @@
         "CertPolicyRequired": false
     },
 
+    "Proxy": {
+        "Required":  false,
+        "Host":  "",
+        "Port":  "",
+        "RequiresCredential":  false,
+        "Credential": ""
+    },
+
     "LogRhythm": {
         "Version":"7.5.0",
         "DataIndexerIP": "127.0.0.1",

--- a/dist/installer/config/Lrt.Config.Input.json
+++ b/dist/installer/config/Lrt.Config.Input.json
@@ -15,6 +15,44 @@
         }
     },
 
+    "Proxy": {
+        "Name": "Proxy",
+        "Optional": false,
+        "Message": "",
+        "HasCredential": true,
+
+        "Fields": {
+            "Required": {
+                "Prompt": "Is a Proxy required for any Web (API) request?",
+                "Hint": "yes or no",
+                "InputCmd": "Get-InputYesNo",
+                "FallThru": false
+            },
+            "Host": {
+                "Prompt": "Proxy host",
+                "Hint": "Hostname or IP (x.x.x.x)",
+                "InputCmd": "Get-InputHostname",
+                "FallThru": false
+            },
+            "Port": {
+                "Prompt": "Proxy port",
+                "Hint": "Integer, typically 80 or 8080",
+                "InputCmd": "Get-StringPattern",
+                "FallThru": false,
+                "InputPattern": {
+                    "Pattern": "^\\d*$",
+                    "AllowChars": ""
+                }
+            },
+            "RequiresCredential": {
+                "Prompt": "Does the Proxy require any credential?",
+                "Hint": "yes or no",
+                "InputCmd": "Get-InputYesNo",
+                "FallThru": false
+            }
+        }
+    },
+
     "LogRhythm": {
         "Name": "LogRhythm",
         "Optional": false,

--- a/dist/installer/include/input/Get-InputCredential.ps1
+++ b/dist/installer/include/input/Get-InputCredential.ps1
@@ -7,8 +7,12 @@ Function Get-InputCredential {
         Prompts to overwrite if the credential exists.
     .PARAMETER AppId
         The object identifier for an application from Lrt.Config.Input (example: "LogRhythmEcho")
-    .PARAMETER AppDescr
+    .PARAMETER AppName
         The value of the "Name" field of an application from Lrt.Config.Input (example: "LogRhythm Echo")
+    .PARAMETER Username
+        The value of the "Username" part of the credential object
+    .PARAMETER UserCredential
+        Switch from asking for an API Key to ask for a User PassewThe value of the "Username" part of the credential object
     .EXAMPLE
         PS C:\> 
     #>
@@ -27,7 +31,11 @@ Function Get-InputCredential {
 
         [Parameter(Mandatory = $false, Position = 3)]
         [ValidateNotNullOrEmpty()]
-        [string] $Username
+        [string] $Username,
+
+
+        [Parameter(Mandatory = $false, Position = 4)]
+        [switch] $UserCredential = $false
     )
 
     # LogRhythm.ApiKey.key
@@ -44,7 +52,13 @@ Function Get-InputCredential {
 
 
     # Determine the filename and save location for this key
-    $KeyFileName = $AppId + ".ApiKey.xml"
+    if ($UserCredential) {
+        $KeyFileName = $AppId + ".Credential.xml"
+    }
+    else
+    {
+        $KeyFileName = $AppId + ".ApiKey.xml"
+    }
     $KeyPath = Join-Path -Path $ConfigDirPath -ChildPath $KeyFileName
     
     # Prompt to Overwrite existing key
@@ -56,13 +70,19 @@ Function Get-InputCredential {
     }
 
 
-    # Prompt for Key
+    # Prompt for Key / Password
     $Key = ""
-    while ($Key.Length -lt 10) {
-        $Key = Read-Host -AsSecureString -Prompt "  > API Key for $AppName"
-        if ($Key.Length -lt 10) {
-            # Hint
-            Write-Host "    Key less than 10 characters." -ForegroundColor Magenta
+    if ($UserCredential) {
+            $Key = Read-Host -AsSecureString -Prompt "  > Password for $AppName"
+    }
+    else
+    {
+        while ($Key.Length -lt 10) {
+            $Key = Read-Host -AsSecureString -Prompt "  > API Key for $AppName"
+            if ($Key.Length -lt 10) {
+                # Hint
+                Write-Host "    Key less than 10 characters." -ForegroundColor Magenta
+            }
         }
     }
     

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -91,7 +91,7 @@ foreach ($include in $Includes.GetEnumerator()) {
 
 
 
-#region: Import API Keys and Proxy Password
+#region: Import API Keys and Credential (Username + Password)
 foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
     # Import API Keys
     if($ConfigCategory.Value.PSObject.Properties.Name -eq "ApiKey") {
@@ -105,37 +105,37 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
         }
     }
 
-    # Proxy Password
-    if($ConfigCategory.Value.PSObject.Properties.Name -eq "ProxyCredential") {
-        $KeyFileName = $ConfigCategory.Name + ".ProxyCredential.xml"
+    # Credential
+    if($ConfigCategory.Value.PSObject.Properties.Name -eq "Credential") {
+        $KeyFileName = $ConfigCategory.Name + ".Credential.xml"
         $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
         if ($KeyFile.Exists) {
-            $LrtConfig.($ConfigCategory.Name).ProxyCredential = Import-Clixml -Path $KeyFile.FullName
-            Write-Verbose "[$($ConfigCategory.Name)]: Loaded Proxy Password"
+            $LrtConfig.($ConfigCategory.Name).Credential = Import-Clixml -Path $KeyFile.FullName
+            Write-Verbose "[$($ConfigCategory.Name)]: Loaded Credential"
         } else {
-            Write-Verbose "[$($ConfigCategory.Name)]: Proxy password not found"
+            Write-Verbose "[$($ConfigCategory.Name)]: Credential not found"
         }
     }
 }
 #endregion
 
 #region: Bring Proxy settings to global:PSDefaultParameterValues 
-if ($LrtConfig.General.ProxyRequired -And ($LrtConfig.General.ProxyURL.Length -gt 0)) {
+if ($LrtConfig.Proxy.Required -And ($LrtConfig.Proxy.Url.Length -gt 0)) {
     # Proxy URL
     if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:Proxy')) {
-        $PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.General.ProxyURL)
+        $PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.Proxy.Url)
     }
     if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:Proxy')) {
-        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.General.ProxyURL)
+        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.Proxy.Url)
     }
 
     # Credential
-    if ($LrtConfig.General.ProxyRequiresCredential -And ($LrtConfig.General.ProxyCredential.GetType().Name -eq 'PSCredential')) {
+    if ($LrtConfig.Proxy.RequiresCredential -And ($LrtConfig.Proxy.Credential.GetType().Name -eq 'PSCredential')) {
         if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:ProxyCredential')) {
-            $PSDefaultParameterValues.Add('Invoke-RestMethod:ProxyCredential',$LrtConfig.General.ProxyCredential)
+            $PSDefaultParameterValues.Add('Invoke-RestMethod:ProxyCredential',$LrtConfig.Proxy.Credential)
         }
         if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:ProxyCredential')) {
-            $PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.General.ProxyCredential)
+            $PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.Proxy.Credential)
         }
     }
 }

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -120,13 +120,17 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
 #endregion
 
 #region: Bring Proxy settings to global:PSDefaultParameterValues 
-if ($LrtConfig.Proxy.Required -And ($LrtConfig.Proxy.Url.Length -gt 0)) {
+if ($LrtConfig.Proxy.Required -And ($LrtConfig.Proxy.Host.Length -gt 0)) {
     # Proxy URL
+    $ProxyUrl = "http://{0}" -f $LrtConfig.Proxy.Host
+    if ($LrtConfig.Proxy.Port.Length -gt 0) {
+        $ProxyUrl += ":{0}" -f $LrtConfig.Proxy.Port
+    }
     if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:Proxy')) {
-        $PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.Proxy.Url)
+        $PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy', $ProxyUrl)
     }
     if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:Proxy')) {
-        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.Proxy.Url)
+        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy', $ProxyUrl)
     }
 
     # Credential
@@ -138,6 +142,7 @@ if ($LrtConfig.Proxy.Required -And ($LrtConfig.Proxy.Url.Length -gt 0)) {
             $PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.Proxy.Credential)
         }
     }
+
 }
 #endregion
 

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -91,9 +91,8 @@ foreach ($include in $Includes.GetEnumerator()) {
 
 
 
-#region: Import API Keys and Proxy Password
+#region: Import API Keys                                                                 
 foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
-    # Import API Keys
     if($ConfigCategory.Value.PSObject.Properties.Name -eq "ApiKey") {
         $KeyFileName = $ConfigCategory.Name + ".ApiKey.xml"
         $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
@@ -102,18 +101,6 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
             Write-Verbose "[$($ConfigCategory.Name)]: Loaded API Key"
         } else {
             Write-Verbose "[$($ConfigCategory.Name)]: API key not found"
-        }
-    }
-
-    # Proxy Password
-    if($ConfigCategory.Value.PSObject.Properties.Name -eq "ProxyCredentials") {
-        $KeyFileName = $ConfigCategory.Name + ".ProxyCredentials.xml"
-        $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
-        if ($KeyFile.Exists) {
-            $LrtConfig.($ConfigCategory.Name).ProxyCredentials = Import-Clixml -Path $KeyFile.FullName
-            Write-Verbose "[$($ConfigCategory.Name)]: Loaded Proxy Password"
-        } else {
-            Write-Verbose "[$($ConfigCategory.Name)]: Proxy password not found"
         }
     }
 }

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -91,8 +91,9 @@ foreach ($include in $Includes.GetEnumerator()) {
 
 
 
-#region: Import API Keys                                                                 
+#region: Import API Keys and Proxy Password
 foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
+    # Import API Keys
     if($ConfigCategory.Value.PSObject.Properties.Name -eq "ApiKey") {
         $KeyFileName = $ConfigCategory.Name + ".ApiKey.xml"
         $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
@@ -101,6 +102,18 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
             Write-Verbose "[$($ConfigCategory.Name)]: Loaded API Key"
         } else {
             Write-Verbose "[$($ConfigCategory.Name)]: API key not found"
+        }
+    }
+
+    # Proxy Password
+    if($ConfigCategory.Value.PSObject.Properties.Name -eq "ProxyCredentials") {
+        $KeyFileName = $ConfigCategory.Name + ".ProxyCredentials.xml"
+        $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
+        if ($KeyFile.Exists) {
+            $LrtConfig.($ConfigCategory.Name).ProxyCredentials = Import-Clixml -Path $KeyFile.FullName
+            Write-Verbose "[$($ConfigCategory.Name)]: Loaded Proxy Password"
+        } else {
+            Write-Verbose "[$($ConfigCategory.Name)]: Proxy password not found"
         }
     }
 }

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -91,8 +91,9 @@ foreach ($include in $Includes.GetEnumerator()) {
 
 
 
-#region: Import API Keys                                                                 
+#region: Import API Keys and Proxy Password
 foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
+    # Import API Keys
     if($ConfigCategory.Value.PSObject.Properties.Name -eq "ApiKey") {
         $KeyFileName = $ConfigCategory.Name + ".ApiKey.xml"
         $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
@@ -101,6 +102,18 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
             Write-Verbose "[$($ConfigCategory.Name)]: Loaded API Key"
         } else {
             Write-Verbose "[$($ConfigCategory.Name)]: API key not found"
+        }
+    }
+
+    # Proxy Password
+    if($ConfigCategory.Value.PSObject.Properties.Name -eq "ProxyCredential") {
+        $KeyFileName = $ConfigCategory.Name + ".ProxyCredential.xml"
+        $KeyFile = [System.IO.FileInfo]::new("$ConfigDirPath\$KeyFileName")
+        if ($KeyFile.Exists) {
+            $LrtConfig.($ConfigCategory.Name).ProxyCredential = Import-Clixml -Path $KeyFile.FullName
+            Write-Verbose "[$($ConfigCategory.Name)]: Loaded Proxy Password"
+        } else {
+            Write-Verbose "[$($ConfigCategory.Name)]: Proxy password not found"
         }
     }
 }

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -119,6 +119,27 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
 }
 #endregion
 
+#region: Bring Proxy settings to global:PSDefaultParameterValues 
+if ($LrtConfig.General.ProxyRequired -And ($LrtConfig.General.ProxyURL.Length -gt 0)) {
+    # Proxy URL
+    if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:Proxy')) {
+        $global:PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.General.ProxyURL)
+    }
+    if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:Proxy')) {
+        $global:PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.General.ProxyURL)
+    }
+
+    # Credential
+    if ($LrtConfig.General.ProxyRequiresCredential -And ($LrtConfig.General.ProxyCredential.GetType().Name -eq 'PSCredential')) {
+        if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:ProxyCredential')) {
+            $global:PSDefaultParameterValues.Add('Invoke-RestMethod:ProxyCredential',$LrtConfig.General.ProxyCredential)
+        }
+        if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:ProxyCredential')) {
+            $global:PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.General.ProxyCredential)
+        }
+    }
+}
+#endregion
 
 
 #region: Export Module Members                                                           

--- a/src/LogRhythm.Tools.psm1
+++ b/src/LogRhythm.Tools.psm1
@@ -122,20 +122,20 @@ foreach($ConfigCategory in $LrtConfig.PSObject.Properties) {
 #region: Bring Proxy settings to global:PSDefaultParameterValues 
 if ($LrtConfig.General.ProxyRequired -And ($LrtConfig.General.ProxyURL.Length -gt 0)) {
     # Proxy URL
-    if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:Proxy')) {
-        $global:PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.General.ProxyURL)
+    if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:Proxy')) {
+        $PSDefaultParameterValues.Add('Invoke-RestMethod:Proxy',$LrtConfig.General.ProxyURL)
     }
-    if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:Proxy')) {
-        $global:PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.General.ProxyURL)
+    if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:Proxy')) {
+        $PSDefaultParameterValues.Add('Invoke-WebRequest:Proxy',$LrtConfig.General.ProxyURL)
     }
 
     # Credential
     if ($LrtConfig.General.ProxyRequiresCredential -And ($LrtConfig.General.ProxyCredential.GetType().Name -eq 'PSCredential')) {
-        if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:ProxyCredential')) {
-            $global:PSDefaultParameterValues.Add('Invoke-RestMethod:ProxyCredential',$LrtConfig.General.ProxyCredential)
+        if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-RestMethod:ProxyCredential')) {
+            $PSDefaultParameterValues.Add('Invoke-RestMethod:ProxyCredential',$LrtConfig.General.ProxyCredential)
         }
-        if (-Not $global:PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:ProxyCredential')) {
-            $global:PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.General.ProxyCredential)
+        if (-Not $PSDefaultParameterValues.ContainsKey('Invoke-WebRequest:ProxyCredential')) {
+            $PSDefaultParameterValues.Add('Invoke-WebRequest:ProxyCredential',$LrtConfig.General.ProxyCredential)
         }
     }
 }


### PR DESCRIPTION
### Proxy Awareness
:sparkles: New feature

The goal is to be able to provide Proxy details and credential for people who are required to go through a proxy.

This PR includes changes to:
- **`LogRhythm.Tools.psm1`**
  - Load proxy credentials from .XML file if needed
  - put proxy settings (Host, Port and credentials if needed) in `$PSDefaultParameterValues`

- **`LogRhythm.Tools.json` & `Lrt.Config.Input.json`**
  - Add new "Proxy" top branch
  - Add its fields

- **`Setup.ps1` & `Get-InputCredential.ps1`**
  - Add collection of User credentials (Username and Password)
  - save them in `$AppId + ".Credential.xml"` (as opposed to `".ApiKey.xml"`)

