### PR TITLE
No UseContext unless GeneralValue list

### DIFF
--- a/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
@@ -185,7 +185,7 @@ Function New-LrList {
     Begin {
         # Request Setup
         $Me = $MyInvocation.MyCommand.Name
-        $BaseUrl = $LrtConfig.LogRhythm.AdminBaseUrl
+        $BaseUrl = $LrtConfig.LogRhythm.BaseUrl
         $Token = $Credential.GetNetworkCredential().Password
 
         # Define HTTP Headers
@@ -195,7 +195,7 @@ Function New-LrList {
 
         # Request Setup
         $Method = $HttpMethod.Post
-        $RequestUrl = $BaseUrl + "/lists/"
+        $RequestUrl = $BaseUrl + "/lr-admin-api/lists/"
 
         # Define HTTP Method
         $Method = $HttpMethod.Post
@@ -304,8 +304,9 @@ Function New-LrList {
         }
 
         if ($ListType -eq "GeneralValue") {
-            $BodyContents.Add("useContext", @($FinalContext))
+            $BodyContents | Add-Member -MemberType NoteProperty -Name 'useContext' -Value @($FinalContext)
         }
+ 
 
         $Body = $BodyContents | ConvertTo-Json -Depth 5 -Compress
         Write-Verbose "[$Me] Request Body:`n$Body"

--- a/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
@@ -288,7 +288,6 @@ Function New-LrList {
             guid = $Guid
             shortDescription = $ShortDescription
             longDescription = $LongDescription
-            useContext = @($FinalContext)
             autoImportOption = [PSCustomObject]@{
                 enabled = $AutoImport
                 usePatterns = $AutoImportPatterns
@@ -303,7 +302,10 @@ Function New-LrList {
             doesExpire = $DoesExpire
             owner = $Owner
         }
- 
+
+        if ($ListType -eq "GeneralValue") {
+            $BodyContents.Add("useContext", @($FinalContext))
+        }
 
         $Body = $BodyContents | ConvertTo-Json -Depth 5 -Compress
         Write-Verbose "[$Me] Request Body:`n$Body"


### PR DESCRIPTION
Goes to addressing #73

When creating a new list, only add the **useContext** property when the list is of **GeneralValue** type.

The source branch I was working from seems to have adjusted BaseUrl variable already (nice), even though I used the development branch as the starting point and I can see in the source that these are updated in the development branch.

I have again tested this in one of our environments for both an IP list as well as a General Value list.