### PR TITLE
Added Get-RfSoarEnrichment

### DIFF
--- a/src/Public/RecordedFuture/General/Get-RfSoarEnrichment.ps1
+++ b/src/Public/RecordedFuture/General/Get-RfSoarEnrichment.ps1
@@ -1,0 +1,87 @@
+using namespace System
+using namespace System.Collections.Generic
+
+function Get-RfSoarEnrichment {
+    <#
+        .SYNOPSIS
+            Get-RfSoarEnrichment calls the RecordedFuture SOAR Enrichment API to get additional information about IoCs (called Entities by RF)
+
+        .DESCRIPTION
+            Get RecordedFuture SOAR Enrichment makes a call to bulk retrieve information about a list of IoCs
+
+        .PARAMETER Credential
+            PSCredential containing an API Token in the Password field.
+            
+            Note: You can bypass the need to provide a Credential by setting
+            the preference variable $LrtConfig.RecordedFuture.RfApiToken
+            with a valid Api Token.
+
+        .PARAMETER IoCList
+            PSCustomObject containing arrays of IoCs for which to get enrichment data
+            $IoCList = [PSCustomObject]@{
+                ip = @{$IpList}
+                domain = @{$DomainList}
+                vulnerability = @{$cveList}
+                hash = @{$HashList}
+                url = @{$UrlList}
+            }
+            Any one or more of the IoC Types can be specified, each may have one or more entries.
+
+        .EXAMPLE
+            $IoCList = [PSCustomObject]@{
+                ip = {'1.1.188.10'}
+            }
+            PS C:\> Get-RfSoarEnrichment -IoCList $IoCList
+            ---
+            risk        : {score: 89}
+            ...
+
+    #>
+
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, Position = 0)]
+        [ValidateNotNullOrEmpty()]
+        [PsCustomObject] $IoCList,
+
+
+        [Parameter(Mandatory = $false, Position = 1)]
+        [ValidateNotNull()]
+        [pscredential] $Credential = $LrtConfig.RecordedFuture.ApiKey
+    )
+
+    Begin {
+        $Me = $MyInvocation.MyCommand.Name
+
+        $BaseUrl = $LrtConfig.RecordedFuture.BaseUrl
+        $Token = $Credential.GetNetworkCredential().Password
+
+        $Headers = [Dictionary[string,string]]::new()
+        $Headers.Add("X-RFToken", "$Token")
+        $Headers.Add("Content-Type","application/json")
+    }
+
+    Process {
+        # Request URI   
+        $Method = $HttpMethod.post
+        $RequestUrl = $BaseUrl + "/soar/enrichment?metadata=false"
+        Write-Verbose "[$Me]: RequestUrl: $RequestUrl"
+
+        $Body = $IoCList | ConvertTo-Json -Depth 5 -Compress
+        Write-Verbose "[$Me] Request Body:`n$Body"
+
+        Try {
+            $rfResponse = Invoke-RestMethod -Uri $RequestUrl -Method $Method -Headers $Headers -Body $Body
+        }
+        catch [System.Net.WebException] {
+            $Err = Get-RestErrorMessage $_
+            throw [Exception] "[$Me] [$($Err.statusCode)]: $($Err.message) $($Err.details)`n$($Err.validationErrors)`n"
+        }
+
+        Return $rfResponse
+    }
+ 
+
+    End {}
+
+}


### PR DESCRIPTION
Added Get-RfSoarEnrichment cmd to pull data about list of IoCs from RF's API

[Documentation](https://support.recordedfuture.com/hc/en-us/articles/360041711393-SOAR-API-Overview)
[API Reference](https://api.recordedfuture.com/v2/#!/SOAR/SOAR_lookup_of_entities)

Documentation at start of function is not completely accurate.

I tested with:

````powershell
$IoCList = @{
ip = @( '1.1.188.10','1.1.1.1')
}
$SoarData = Get-RfSoarEnrichment -IoCList $IoCList
```
