### PR TITLE
Use -ResultsOnly option on Get-LrAlarm

### DIFF
--- a/src/Public/LogRhythm/Alarms/Update-LrAlarm.ps1
+++ b/src/Public/LogRhythm/Alarms/Update-LrAlarm.ps1
@@ -145,7 +145,7 @@ Function Update-LrAlarm {
                 $ErrorObject.Raw = $ValidStatus
             }
         } else {
-            $AlarmDetails = Get-LrAlarm -AlarmId $AlarmId
+            $AlarmDetails = Get-LrAlarm -AlarmId $AlarmId -ResultsOnly
             if ($AlarmDetails.error -ne $true) {
                 $ValidStatus = Test-LrAlarmStatus -Id $AlarmDetails.alarmStatus
                 $_alarmStatus = $ValidStatus.AlarmStatus


### PR DESCRIPTION
Addressess #77 by adding the **-ResultsOnly** option on **Get-LrAlarm** to return the properties directly rather than as a sub-object.  The subsequent reference to **$AlarmDetails.alarmStatus** is now valid.