### PR TITLE
Add RuleBlockId to AIE Drilldown Results/Summary data

### DIFF
--- a/src/Public/LogRhythm/AIE/Get-LrAieDrilldown.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieDrilldown.ps1
@@ -194,10 +194,10 @@ Function Get-LrAieDrilldown {
         foreach ($ruleBlock in $_dd.RuleBlocks) {
             foreach ($field in $ruleBlock.DDSummaries) {
                 $fields = [PSCustomObject]@{
+                    RuleBlockId = ($ruleBlock.RuleBlockId)
                     FieldName = $($field.PIFType | Get-PIFTypeName)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
-                    RuleBlockId = ($ruleBlock.RuleBlockId)
                 }
                 $SummaryFields.Add($fields)
             }

--- a/src/Public/LogRhythm/AIE/Get-LrAieDrilldown.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieDrilldown.ps1
@@ -197,6 +197,7 @@ Function Get-LrAieDrilldown {
                     FieldName = $($field.PIFType | Get-PIFTypeName)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
+                    RuleBlockId = ($ruleBlock.RuleBlockId)
                 }
                 $SummaryFields.Add($fields)
             }

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -158,13 +158,14 @@ Function Get-LrAieSummary {
         foreach ($ruleBlock in $_dd.RuleBlocks) {
             foreach ($field in $ruleBlock.DDSummaries) {
                 $fields = [PSCustomObject]@{
-                    FieldName = $($field.PIFType)
+                    FieldName = $($field.PIFType | Get-PIFTypeName)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
                     RuleBlockId = ($ruleBlock.RuleBlockId)
                 }
+                $SummaryFields.Add($fields)
             }
-            $SummaryFields.Add($fields)
+
         }
 
         # Done!

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -158,7 +158,7 @@ Function Get-LrAieSummary {
         foreach ($ruleBlock in $_dd.RuleBlocks) {
             foreach ($field in $ruleBlock.DDSummaries) {
                 $fields = [PSCustomObject]@{
-                    FieldName = $field.PIFType
+                    FieldName = $($field.PIFType)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
                     RuleBlockId = ($ruleBlock.RuleBlockId)

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -162,6 +162,7 @@ Function Get-LrAieSummary {
                 $FieldName = $field.PIFType
                 $FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                 $fields.Add($FieldName, $FieldValue)
+                $fields.Add('RuleBlockId', $ruleBlock.RuleBlockId)
             }
             $SummaryFields.Add($fields)
         }

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -154,14 +154,15 @@ Function Get-LrAieSummary {
         $_dd = $Response.Data.drilldownsummary
 
         # Get Summary Fields
-        $SummaryFields = [List[Dictionary[string,string]]]::new()
+        $SummaryFields = [List[object]]::new()
         foreach ($ruleBlock in $_dd.RuleBlocks) {
-            $fields = [Dictionary[string,string]]::new()
-
             foreach ($field in $ruleBlock.DDSummaries) {
-                $FieldName = $field.PIFType
-                $FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
-                $fields.Add($FieldName, $FieldValue)
+                $fields = [PSCustomObject]@{
+                    FieldName = $field.PIFType
+                    FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
+                    FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
+                    RuleBlockId = ($ruleBlock.RuleBlockId)
+                }
             }
             $SummaryFields.Add($fields)
         }

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -158,7 +158,7 @@ Function Get-LrAieSummary {
         foreach ($ruleBlock in $_dd.RuleBlocks) {
             foreach ($field in $ruleBlock.DDSummaries) {
                 $fields = [PSCustomObject]@{
-                    FieldName = $($field.PIFType | Get-PIFTypeName)
+                    FieldName = $($field.PIFType)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
                     RuleBlockId = ($ruleBlock.RuleBlockId)

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -158,10 +158,10 @@ Function Get-LrAieSummary {
         foreach ($ruleBlock in $_dd.RuleBlocks) {
             foreach ($field in $ruleBlock.DDSummaries) {
                 $fields = [PSCustomObject]@{
+                    RuleBlockId = ($ruleBlock.RuleBlockId)
                     FieldName = $($field.PIFType)
                     FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                     FieldCount = ($field.DrillDownSummaryLogs | ConvertFrom-Json).value
-                    RuleBlockId = ($ruleBlock.RuleBlockId)
                 }
                 $SummaryFields.Add($fields)
             }

--- a/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
+++ b/src/Public/LogRhythm/AIE/Get-LrAieSummary.ps1
@@ -162,7 +162,6 @@ Function Get-LrAieSummary {
                 $FieldName = $field.PIFType
                 $FieldValue = ($field.DrillDownSummaryLogs | ConvertFrom-Json).field
                 $fields.Add($FieldName, $FieldValue)
-                $fields.Add('RuleBlockId', $ruleBlock.RuleBlockId)
             }
             $SummaryFields.Add($fields)
         }


### PR DESCRIPTION
As per issue #81, includes the RuleBlock Id in the SummaryFields output of Get-AieDrilldown as well as in the output of Get-LrAieSummary.

Additionally, brings the structure of the output of Get-LrAieSummary in line with the SummaryFields data output of Get-AieDrilldown.
