### PR TITLE
🐛 Fix RecordStatus casing Identities API in LR v7.8+

### DIFF
--- a/src/Public/LogRhythm/Admin/Identities/Get-LrIdentities.ps1
+++ b/src/Public/LogRhythm/Admin/Identities/Get-LrIdentities.ps1
@@ -216,7 +216,7 @@ Function Get-LrIdentities {
         if ($RecordStatus) {
             $ValidStatus = "active", "retired"
             if ($ValidStatus.Contains($($RecordStatus.ToLower()))) {
-                $_recordStatus = $RecordStatus.ToLower()
+                $_recordStatus = [CultureInfo]::InvariantCulture.TextInfo.ToTitleCase($RecordStatus.ToLowerInvariant())
                 $QueryParams.Add("recordStatus", $_recordStatus)
             } else {
                 throw [ArgumentException] "RecordStatus [$RecordStatus] must be: active or retired."


### PR DESCRIPTION
The LR Identities API expects the value to be title cased. Unfortunately I'm unable to test the impact of this change on older LR versions. 