### PR TITLE
Add support for Networks in Add-LrListItem

### DIFF
--- a/src/Public/LogRhythm/Admin/Lists/Add-LrListItem.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/Add-LrListItem.ps1
@@ -514,6 +514,12 @@ Function Add-LrListItem {
                 $ListItemDataType = "Int32"
                 $ListItemType = "MsgSourceType"
             }
+            Network {
+                # Entity Network
+                # Only accepts NetworkIDs
+                $ListItemDataType = "Int32"
+                $ListItemType = "Network"
+            }
             Default {}
         }
 

--- a/src/Public/LogRhythm/Admin/Lists/Remove-LrListItem.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/Remove-LrListItem.ps1
@@ -494,6 +494,12 @@ Function Remove-LrListItem {
                 $ListItemDataType = "Int32"
                 $ListItemType = "MsgSourceType"
             }
+            Network {
+                # Entity Network
+                # Only accepts NetworkIDs
+                $ListItemDataType = "Int32"
+                $ListItemType = "Network"
+            }
             Default {}
         }
 


### PR DESCRIPTION
Network lists accept Integer Network IDs as entries. Added this to the list of supported types.