### PR TITLE
Update List Expire logic

### DIFF
--- a/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/New-LrList.ps1
@@ -322,7 +322,7 @@ Function New-LrList {
             $ErrorObject.Type = "Input.Validation"
             $ErrorObject.Note = "Does expire is set to true, requires input parameter TimeToLiveSeconds to be provided."
             $ErrorObject.FieldType = $ListType
-        } else {
+        } elseif ($DoesExpire) {
             $BodyContents | Add-Member -MemberType NoteProperty -Name 'timeToLiveSeconds' -Value $TimeToLiveSeconds
         }
  

--- a/src/Public/LogRhythm/Admin/Lists/Update-LrList.ps1
+++ b/src/Public/LogRhythm/Admin/Lists/Update-LrList.ps1
@@ -428,7 +428,7 @@ Function Update-LrList {
             $ErrorObject.Type = "Input.Validation"
             $ErrorObject.Note = "Does expire is set to true, requires input parameter TimeToLiveSeconds to be provided."
             $ErrorObject.FieldType = $ListType
-        } else {
+        } elseif ($DoesExpire) {
             $BodyContents | Add-Member -MemberType NoteProperty -Name 'timeToLiveSeconds' -Value $TimeToLiveSeconds
         }
  


### PR DESCRIPTION
Only add TimeToLiveSeconds if list is set to expire, else API returns error.

Previous logic added the TimeToLiveSeconds property to all List Create/Update requests whether set to expire or not. This logic corrects the behaviour so the property is only added if the list is set to expire.