### PR TITLE
Fixes to Get-LrNetworks

### DIFF
--- a/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
+++ b/src/Public/LogRhythm/Admin/Networks/Get-LrNetworks.ps1
@@ -130,11 +130,11 @@ Function Get-LrNetworks {
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 4)]
-        [string] $BIP,
+        [ipaddress] $BIP,
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 5)]
-        [string] $EIP,
+        [ipaddress] $EIP,
 
 
         [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName = $true, Position = 6)]
@@ -285,7 +285,7 @@ Function Get-LrNetworks {
             DO {
                 # Increment Page Count / Offset
                 #$PageCount = $PageCount + 1
-                $Offset = $Offset + 1
+                $Offset += $PageValuesCount
                 # Update Query Paramater
                 $QueryParams.offset = $Offset
                 # Apply to Query String


### PR DESCRIPTION
- Fix #92 by swithing BIP and EIP params to IpAddress
  - Later code references "IPAddressToString" which is a method of the IpAddress object
  - Even if supplied as a string, the IpAdress object converts successfully if it represents a valid IP
- Fix #93 by updating pagination logic
  - The offset is measured in items rather than pages, which is how the previous logic worked
  - When there were more than PageValuesCount items (1000 by default), there would be Total Items - PageValuesCount +1 requests
    - eg. If there are 1261 items, there would be 262 requests
  - This would slow down the process to retrieve all networks, as well as consume additional memory in PowerShell