### PR TITLE
Add test for AddressFamily

### DIFF
--- a/src/Public/General/Test-IPv4AddressInRange.ps1
+++ b/src/Public/General/Test-IPv4AddressInRange.ps1
@@ -21,7 +21,7 @@ param(
             [array]::Reverse($ipAddress)
             $ipAddress = [system.BitConverter]::ToUInt32($ipAddress, 0)
         } else {
-            return $IPValid
+            return $false
         }
 
         if ($BIPValid.IsValid) {
@@ -29,7 +29,7 @@ param(
             [array]::Reverse($bipAddress)
             $bipAddress = [system.BitConverter]::ToUInt32($bipAddress, 0)
         } else {
-            return $BIPValid
+            return $false
         }
 
         if ($EIPValid.IsValid) {
@@ -37,7 +37,7 @@ param(
             [array]::Reverse($eipAddress)
             $eipAddress = [system.BitConverter]::ToUInt32($eipAddress, 0)
         } else {
-            return $EIPValid
+            return $false
         }
 
     

--- a/src/Public/General/Test-ValidIPv4Address.ps1
+++ b/src/Public/General/Test-ValidIPv4Address.ps1
@@ -36,8 +36,8 @@ Function Test-ValidIPv4Address {
         IsPrivate   =   $false
     }
 
-    # Check if ID value is an integer
-    if ($IP -as [ipaddress]) {
+    # Check if IP value is a valid IP address, and is IPv4 by parsing it as an [ipaddress]
+    if ($IP -as [ipaddress] -and ($IP -as [ipaddress]).AddressFamily -eq 'InterNetworkV4') {
         $OutObject.Value = $IP.ToString()
         $OutObject.IsValid = $true
         if ($IP -Match '(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)') {

--- a/src/Public/General/Test-ValidIPv4Address.ps1
+++ b/src/Public/General/Test-ValidIPv4Address.ps1
@@ -37,7 +37,7 @@ Function Test-ValidIPv4Address {
     }
 
     # Check if IP value is a valid IP address, and is IPv4 by parsing it as an [ipaddress]
-    if ($IP -as [ipaddress] -and ($IP -as [ipaddress]).AddressFamily -eq 'InterNetworkV4') {
+    if (($IP -as [ipaddress]) -and ($IP -as [ipaddress]).AddressFamily -eq 'InterNetwork') {
         $OutObject.Value = $IP.ToString()
         $OutObject.IsValid = $true
         if ($IP -Match '(^127\.)|(^192\.168\.)|(^10\.)|(^172\.1[6-9]\.)|(^172\.2[0-9]\.)|(^172\.3[0-1]\.)') {


### PR DESCRIPTION
The [ipaddress] system class supports both IPv4 and IPv6, so just checking that it parses an IP address is insufficient to determine if it is a valid IPv4 address.

This addresses #96 by testing `AddressFamily` of the converted address for a value of **InterNetworkV4**